### PR TITLE
Fix radar geometry to match Simrad Halo 20

### DIFF
--- a/urdf/sensors/radar.xacro
+++ b/urdf/sensors/radar.xacro
@@ -9,20 +9,20 @@
       <visual name="${name}_visual">
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
-          <cylinder radius="0.3" length="0.25"/>
+          <cylinder radius="0.255" length="0.223"/>
         </geometry>
       </visual>
       <collision name="${name}_collision">
         <geometry>
-          <cylinder radius="0.3" length="0.25"/>
+          <cylinder radius="0.255" length="0.223"/>
         </geometry>
       </collision>
       <inertial>
-        <mass value="1"/>
+        <mass value="5.9"/>
         <inertia
-          ixx="0.00109375"
-          iyy="0.00109375"
-          izz="0.00125"
+          ixx="0.12"
+          iyy="0.12"
+          izz="0.096"
           ixy="0"
           ixz="0"
           iyz="0"/>


### PR DESCRIPTION
## Summary

- Update radar link cylinder to match Simrad Halo 20 specs: 510mm diameter, 223mm height
- Update mass to 5.9 kg (from placeholder 1 kg) with recomputed inertia

Closes #5

## Test plan

- [x] Launch `display_launch.py` and verify radar dome size looks correct in RViz

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
