### PR TITLE
feat: waterjet propulsion and MBES retractable ram

### DIFF
--- a/rviz/urdf.rviz
+++ b/rviz/urdf.rviz
@@ -73,11 +73,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        ben/engine_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
         ben/forward_camera:
           Alpha: 1
           Show Axes: false
@@ -96,12 +91,32 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
+        ben/jetdrive_deflector:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ben/jetdrive_impeller:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ben/jetdrive_mount:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
         ben/lidar:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
         ben/mbes:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ben/mbes_ram:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -194,11 +209,6 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        ben/propeller_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
         ben/radar:
           Alpha: 1
           Show Axes: false
@@ -218,8 +228,6 @@ Visualization Manager:
         All Enabled: false
         ben/base_link:
           Value: true
-        ben/engine_link:
-          Value: false
         ben/forward_camera:
           Value: true
         ben/forward_camera_optical:
@@ -228,10 +236,18 @@ Visualization Manager:
           Value: true
         ben/heading:
           Value: true
+        ben/jetdrive_deflector:
+          Value: false
+        ben/jetdrive_impeller:
+          Value: false
+        ben/jetdrive_mount:
+          Value: false
         ben/lidar:
           Value: true
         ben/mbes:
           Value: true
+        ben/mbes_ram:
+          Value: false
         ben/motion_sensor:
           Value: true
         ben/pano:
@@ -272,8 +288,6 @@ Visualization Manager:
           Value: true
         ben/pano_6_optical_rviz_mesh:
           Value: false
-        ben/propeller_link:
-          Value: false
         ben/radar:
           Value: true
       Marker Scale: 1
@@ -283,16 +297,18 @@ Visualization Manager:
       Show Names: false
       Tree:
         ben/base_link:
-          ben/engine_link:
-            ben/propeller_link:
-              {}
           ben/forward_camera:
             ben/forward_camera_optical:
               {}
+          ben/jetdrive_mount:
+            ben/jetdrive_deflector:
+              ben/jetdrive_impeller:
+                {}
           ben/lidar:
             {}
-          ben/mbes:
-            {}
+          ben/mbes_ram:
+            ben/mbes:
+              {}
           ben/motion_sensor:
             ben/gps:
               {}

--- a/urdf/ben_mesh.xacro
+++ b/urdf/ben_mesh.xacro
@@ -61,10 +61,10 @@
   <xacro:property name="forward_camera_y" value="0.1" />
   <xacro:property name="forward_camera_z" value="0.742" />
 
-  <!-- MBES (hull-mounted, relative to MRU) -->
-  <xacro:property name="mbes_x" value="0.0" />
+  <!-- MBES (hull-mounted, on retractable ram, relative to MRU) -->
+  <xacro:property name="mbes_x" value="-0.5" />
   <xacro:property name="mbes_y" value="0.0" />
-  <xacro:property name="mbes_z" value="-1.0" />
+  <xacro:property name="mbes_z" value="-0.4" />
 
   <!-- GPS (POSMV-mounted, relative to motion_sensor) -->
   <xacro:property name="gps_x" value="-0.953" />
@@ -73,10 +73,10 @@
 
   <!-- Heading sensor at motion_sensor origin (no offset) -->
 
-  <!-- Jetdrive engine (hull-mounted, relative to MRU) -->
-  <xacro:property name="engine_x" value="-1.6" />
-  <xacro:property name="engine_y" value="0.0" />
-  <xacro:property name="engine_z" value="-0.35" />
+  <!-- Jetdrive (stern, hull-mounted, relative to MRU) -->
+  <xacro:property name="jetdrive_x" value="-1.1" />
+  <xacro:property name="jetdrive_y" value="0.0" />
+  <xacro:property name="jetdrive_z" value="-0.1" />
 
   <!-- ============================================================
        End of survey offsets
@@ -148,8 +148,7 @@
 
   <xacro:include filename="$(find ben_description)/urdf/sensors/mbes.xacro" />
   <xacro:ben_mbes name="mbes"
-    x="${mru_x + mbes_x}" y="${mru_y + mbes_y}" z="${mru_z + mbes_z}"
-    R="${radians(180)}"/>
+    x="${mru_x + mbes_x}" y="${mru_y + mbes_y}" z="${mru_z + mbes_z}"/>
 
   <!-- POSMV-mounted sensors (positions relative to motion_sensor) -->
 
@@ -159,10 +158,10 @@
   <xacro:include filename="$(find ben_description)/urdf/sensors/oem_heading_sensor.xacro" />
   <xacro:oem_heading_sensor name="heading"/>
 
-  <!-- Jetdrive -->
+  <!-- Jetdrive (Alamarin-Jet AJ 160 waterjet) -->
 
   <xacro:include filename="$(find ben_description)/urdf/jetdrive.xacro" />
-  <xacro:engine prefix="${namespace}/"
-    position="${mru_x + engine_x} ${mru_y + engine_y} ${mru_z + engine_z}"/>
+  <xacro:ben_jetdrive name="jetdrive"
+    x="${mru_x + jetdrive_x}" y="${mru_y + jetdrive_y}" z="${mru_z + jetdrive_z}"/>
 
 </robot>

--- a/urdf/ben_mesh.xacro
+++ b/urdf/ben_mesh.xacro
@@ -9,17 +9,24 @@
        Source: OnShape CAD model
        ============================================================ -->
 
-  <!-- Hull mass properties (from OnShape) -->
-  <xacro:property name="hull_mass" value="950" />
+  <!-- Hull mass properties.
+       GA drawing (ASV-396-7-000-i0001-01): 883 kg displacement, 0.40m draft.
+       CG lowered from OnShape estimate to ~60% of draft above keel for
+       typical monohull stability. In base_link frame CG_z = 0.186. -->
+  <xacro:property name="hull_mass" value="883" />
   <xacro:property name="cg_x" value="-0.911" />
   <xacro:property name="cg_y" value="-0.018" />
-  <xacro:property name="cg_z" value="-0.182" />
-  <xacro:property name="ixx" value="280.97548467" />
-  <xacro:property name="ixy" value="-9.237803" />
-  <xacro:property name="ixz" value="-2.02566202" />
-  <xacro:property name="iyy" value="866.01489076" />
-  <xacro:property name="iyz" value="-0.43969229" />
-  <xacro:property name="izz" value="793.7913527" />
+  <xacro:property name="cg_z" value="-0.346" />
+  <!-- Inertia estimated as uniform-density box from GA drawing dimensions
+       (4.17m x 1.58m x 0.63m at 883 kg). OnShape CAD values were unreliable
+       and off-diagonal products caused capsizing when amplified by sensor-mass
+       merging during URDF-to-SDF fixed joint conversion. -->
+  <xacro:property name="ixx" value="212.9" />
+  <xacro:property name="ixy" value="0.0" />
+  <xacro:property name="ixz" value="0.0" />
+  <xacro:property name="iyy" value="1308.7" />
+  <xacro:property name="iyz" value="0.0" />
+  <xacro:property name="izz" value="1463.2" />
 
   <!-- POSMV MRU location relative to base_link.
        The visual/collision meshes were authored with their origin at this point,
@@ -114,8 +121,10 @@
 
   <link name="${namespace}/motion_sensor">
     <inertial>
-      <mass value="5.0"/>
-      <inertia ixx="0.01" ixy="0.0" ixz="0.0" iyy="0.01" iyz="0.0" izz="0.01"/>
+      <!-- Near-zero mass: sensor link is a reference frame only.
+           Total displacement (883 kg) is accounted for in hull_mass. -->
+      <mass value="0.01"/>
+      <inertia ixx="0.0001" ixy="0.0" ixz="0.0" iyy="0.0001" iyz="0.0" izz="0.0001"/>
     </inertial>
   </link>
 

--- a/urdf/jetdrive.xacro
+++ b/urdf/jetdrive.xacro
@@ -9,21 +9,12 @@
           <box size="0.2 0.15 0.6"/>
         </geometry>
       </visual>
-      <collision name="${prefix}engine_vertical_axis_collision">
-        <origin xyz="-0.16 0 -0.24" rpy="0 0 0" />
-        <geometry>
-          <box size="0.2 0.15 0.83" />
-        </geometry>
-      </collision>
-      <collision name="${prefix}engine_rear_end_collision">
-        <origin xyz="-0.34 0 0.12" rpy="0 0 0" />
-        <geometry>
-          <box size="0.12 0.15 0.12" />
-        </geometry>
-      </collision>
+      <!-- No collision — engine is internal (Alamarin-Jet AJ 160 waterjet).
+           Collision geometries inside the hull mesh cause physics issues
+           when fixed joints are merged during URDF-to-SDF conversion. -->
       <inertial>
-        <mass value="15"/>
-        <inertia ixx="0.889245" ixy="0.0" ixz="0.0" iyy="0.911125" iyz="0.0" izz="0.078125"/>
+        <mass value="0.01"/>
+        <inertia ixx="0.0001" ixy="0.0" ixz="0.0" iyy="0.0001" iyz="0.0" izz="0.0001"/>
       </inertial>
     </link>
 
@@ -34,33 +25,27 @@
           <cylinder radius="0.1" length="0.05"/>
         </geometry>
       </visual>
-      <collision name="${prefix}propeller_collision">
-        <origin xyz="-0.08 0 0" rpy="0 1.57 0" />
-        <geometry>
-          <cylinder length="0.18" radius="0.24" />
-        </geometry>
-      </collision>
+      <!-- No collision — internal waterjet impeller -->
       <inertial>
-        <mass value="0.5"/>
-        <inertia ixx="0.008545" ixy="0.0" ixz="0.0" iyy="0.008545" iyz="0.0" izz="0.0144"/>
+        <mass value="0.01"/>
+        <inertia ixx="0.0001" ixy="0.0" ixz="0.0" iyy="0.0001" iyz="0.0" izz="0.0001"/>
       </inertial>
     </link>
 
-    <joint name="${prefix}chasis_engine_joint" type="revolute">
-      <axis xyz="0 0 1"/>
-      <limit lower="${-pi}" upper="${pi}" effort="10" velocity="10"/>
+    <!-- Both joints fixed: BEN uses an Alamarin-Jet AJ 160 waterjet,
+         not a steerable outboard. The revolute/continuous joints were
+         placeholders from the ROS 2 port. Fixing them until a proper
+         waterjet model is implemented. -->
+    <joint name="${prefix}chasis_engine_joint" type="fixed">
       <origin xyz="${position}" rpy="${orientation}"/>
       <parent link="${namespace}/base_link"/>
       <child link="${prefix}engine_link"/>
     </joint>
 
-    <joint name="${prefix}engine_propeller_joint" type="continuous">
-      <axis rpy="0 0 0" xyz="1 0 0"/>
+    <joint name="${prefix}engine_propeller_joint" type="fixed">
       <parent link="${prefix}engine_link"/>
       <child link="${prefix}propeller_link"/>
       <origin rpy="0 0 0" xyz="-0.278156 0 -0.509371"/>
-      <limit effort="100" velocity="100" />
-      <dynamics friction="0.05" damping="0.05" />
     </joint>
   </xacro:macro>
 </robot>

--- a/urdf/jetdrive.xacro
+++ b/urdf/jetdrive.xacro
@@ -35,7 +35,7 @@
       <parent link="${namespace}/${name}_mount"/>
       <child link="${namespace}/${name}_deflector"/>
       <axis xyz="0 0 1"/>
-      <limit lower="-0.524" upper="0.524" effort="100" velocity="1.0"/>
+      <limit lower="${-radians(30)}" upper="${radians(30)}" effort="100" velocity="1.0"/>
     </joint>
 
     <!-- Impeller — spins to generate thrust force -->

--- a/urdf/jetdrive.xacro
+++ b/urdf/jetdrive.xacro
@@ -52,6 +52,8 @@
       <parent link="${namespace}/${name}_deflector"/>
       <child link="${namespace}/${name}_impeller"/>
       <axis xyz="1 0 0"/>
+      <limit effort="100" velocity="100"/>
+      <dynamics friction="0.05" damping="0.05"/>
     </joint>
 
   </xacro:macro>

--- a/urdf/jetdrive.xacro
+++ b/urdf/jetdrive.xacro
@@ -1,52 +1,58 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro" name="ben_jetdrive">
-  <!-- Macro for inserting an engine with its propeller. -->
-  <xacro:macro name="engine" params="prefix position:='0 0 0' orientation:='0 0 0'">
-    <link name="${prefix}engine_link">
-      <visual>
-        <origin xyz="-0.16 0 -0.24" rpy="0 0 0" />
-        <geometry>
-          <box size="0.2 0.15 0.6"/>
-        </geometry>
-      </visual>
-      <!-- No collision — engine is internal (Alamarin-Jet AJ 160 waterjet).
-           Collision geometries inside the hull mesh cause physics issues
-           when fixed joints are merged during URDF-to-SDF conversion. -->
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <!-- Alamarin-Jet AJ 160 waterjet model.
+       Internal waterjet with deflector/bucket for steering and reverse.
+       No visual/collision — the jet is inside the hull. -->
+  <xacro:macro name="ben_jetdrive" params="name x:=0 y:=0 z:=0">
+
+    <!-- Mount point (fixed to hull, no visual/collision) -->
+    <link name="${namespace}/${name}_mount">
       <inertial>
         <mass value="0.01"/>
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0" iyy="0.0001" iyz="0.0" izz="0.0001"/>
+        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
+                 iyy="0.0001" iyz="0.0" izz="0.0001"/>
       </inertial>
     </link>
 
-    <link name="${prefix}propeller_link">
-      <visual>
-        <origin xyz="-0.08 0 0" rpy="0 1.57 0" />
-        <geometry>
-          <cylinder radius="0.1" length="0.05"/>
-        </geometry>
-      </visual>
-      <!-- No collision — internal waterjet impeller -->
-      <inertial>
-        <mass value="0.01"/>
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0" iyy="0.0001" iyz="0.0" izz="0.0001"/>
-      </inertial>
-    </link>
-
-    <!-- Both joints fixed: BEN uses an Alamarin-Jet AJ 160 waterjet,
-         not a steerable outboard. The revolute/continuous joints were
-         placeholders from the ROS 2 port. Fixing them until a proper
-         waterjet model is implemented. -->
-    <joint name="${prefix}chasis_engine_joint" type="fixed">
-      <origin xyz="${position}" rpy="${orientation}"/>
+    <joint name="${namespace}/${name}_mount_joint" type="fixed">
+      <origin xyz="${x} ${y} ${z}" rpy="0 0 0"/>
       <parent link="${namespace}/base_link"/>
-      <child link="${prefix}engine_link"/>
+      <child link="${namespace}/${name}_mount"/>
     </joint>
 
-    <joint name="${prefix}engine_propeller_joint" type="fixed">
-      <parent link="${prefix}engine_link"/>
-      <child link="${prefix}propeller_link"/>
-      <origin rpy="0 0 0" xyz="-0.278156 0 -0.509371"/>
+    <!-- Deflector/bucket — redirects jet for steering (yaw ±30°) -->
+    <link name="${namespace}/${name}_deflector">
+      <inertial>
+        <mass value="0.01"/>
+        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
+                 iyy="0.0001" iyz="0.0" izz="0.0001"/>
+      </inertial>
+    </link>
+
+    <joint name="${namespace}/${name}_deflector_joint" type="revolute">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <parent link="${namespace}/${name}_mount"/>
+      <child link="${namespace}/${name}_deflector"/>
+      <axis xyz="0 0 1"/>
+      <limit lower="-0.524" upper="0.524" effort="100" velocity="1.0"/>
     </joint>
+
+    <!-- Impeller — spins to generate thrust force -->
+    <link name="${namespace}/${name}_impeller">
+      <inertial>
+        <mass value="0.01"/>
+        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
+                 iyy="0.0001" iyz="0.0" izz="0.0001"/>
+      </inertial>
+    </link>
+
+    <joint name="${namespace}/${name}_impeller_joint" type="continuous">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <parent link="${namespace}/${name}_deflector"/>
+      <child link="${namespace}/${name}_impeller"/>
+      <axis xyz="1 0 0"/>
+    </joint>
+
   </xacro:macro>
 </robot>
-

--- a/urdf/sensors/forward_camera.xacro
+++ b/urdf/sensors/forward_camera.xacro
@@ -22,7 +22,7 @@
           <box size="0.036 0.03 0.03"/>
         </geometry>
       </collision>
-      <!-- Model inertia as box with <size>0.078 0.03 0.03</size> -->
+      <!-- Near-zero inertia: sensor mass is accounted for in hull_mass -->
       <inertial>
         <mass value="0.01"/>
         <inertia

--- a/urdf/sensors/forward_camera.xacro
+++ b/urdf/sensors/forward_camera.xacro
@@ -24,11 +24,11 @@
       </collision>
       <!-- Model inertia as box with <size>0.078 0.03 0.03</size> -->
       <inertial>
-        <mass value="0.3"/>
+        <mass value="0.01"/>
         <inertia
-          ixx="0.0000450"
-          iyy="0.0001746"
-          izz="0.0001746"
+          ixx="0.0001"
+          iyy="0.0001"
+          izz="0.0001"
           ixy="0"
           ixz="0"
           iyz="0"/>

--- a/urdf/sensors/lidar.xacro
+++ b/urdf/sensors/lidar.xacro
@@ -18,11 +18,11 @@
         </geometry>
       </collision>
       <inertial>
-        <mass value="1"/>
+        <mass value="0.01"/>
         <inertia
-          ixx="0.00109375"
-          iyy="0.00109375"
-          izz="0.00125"
+          ixx="0.0001"
+          iyy="0.0001"
+          izz="0.0001"
           ixy="0"
           ixz="0"
           iyz="0"/>

--- a/urdf/sensors/mbes.xacro
+++ b/urdf/sensors/mbes.xacro
@@ -1,38 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="ben_mbes" params="name
-                                        x:=0.0 y:=0.0 z:=-1.0
-                                        R:=3.14 P:=0 Y:=0">
+  <!-- Kongsberg EM 2040P MBES on retractable ram.
+       Travel = max_draft(630mm) - hull_draft(404mm) = 226mm downward.
+       No visual/collision — hull mesh includes the ram housing. -->
+  <xacro:macro name="ben_mbes" params="name x:=0 y:=0 z:=0">
 
-    <link name="${namespace}/${name}">
-      <visual name="${name}_visual">
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <cylinder radius="0.3" length="0.25"/>
-        </geometry>
-      </visual>
-      <collision name="${name}_collision">
-        <geometry>
-          <cylinder radius="0.3" length="0.25"/>
-        </geometry>
-      </collision>
+    <!-- Ram — prismatic joint for vertical travel (0 to -0.226 m) -->
+    <link name="${namespace}/${name}_ram">
       <inertial>
         <mass value="0.01"/>
-        <inertia
-          ixx="0.0001"
-          iyy="0.0001"
-          izz="0.0001"
-          ixy="0"
-          ixz="0"
-          iyz="0"/>
+        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
+                 iyy="0.0001" iyz="0.0" izz="0.0001"/>
       </inertial>
     </link>
 
-    <joint name="${namespace}/base_link_to_${name}_joint" type="fixed">
-      <origin xyz="${x} ${y} ${z}" rpy="${R} ${P} ${Y}" />
-      <parent link="${namespace}/base_link" />
-      <child link="${namespace}/${name}" />
+    <joint name="${namespace}/${name}_ram_joint" type="prismatic">
+      <origin xyz="${x} ${y} ${z}" rpy="0 0 0"/>
+      <parent link="${namespace}/base_link"/>
+      <child link="${namespace}/${name}_ram"/>
+      <axis xyz="0 0 1"/>
+      <limit lower="-0.226" upper="0.0" effort="100" velocity="0.05"/>
     </joint>
+
+    <!-- MBES transducer — TF frame only (like radar) -->
+    <link name="${namespace}/${name}">
+      <inertial>
+        <mass value="0.01"/>
+        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
+                 iyy="0.0001" iyz="0.0" izz="0.0001"/>
+      </inertial>
+    </link>
+
+    <joint name="${namespace}/${name}_joint" type="fixed">
+      <origin xyz="0 0 0" rpy="${radians(180)} 0 0"/>
+      <parent link="${namespace}/${name}_ram"/>
+      <child link="${namespace}/${name}"/>
+    </joint>
+
   </xacro:macro>
 </robot>

--- a/urdf/sensors/mbes.xacro
+++ b/urdf/sensors/mbes.xacro
@@ -18,11 +18,11 @@
         </geometry>
       </collision>
       <inertial>
-        <mass value="1"/>
+        <mass value="0.01"/>
         <inertia
-          ixx="0.00109375"
-          iyy="0.00109375"
-          izz="0.00125"
+          ixx="0.0001"
+          iyy="0.0001"
+          izz="0.0001"
           ixy="0"
           ixz="0"
           iyz="0"/>

--- a/urdf/sensors/oem_gps.xacro
+++ b/urdf/sensors/oem_gps.xacro
@@ -17,8 +17,8 @@
       </collision>
 
       <inertial>
-        <mass value="1"/>
-        <inertia ixx="0.006458" ixy="0.0" ixz="0.0" iyy="0.006458" iyz="0.0" izz="0.01125"/>
+        <mass value="0.01"/>
+        <inertia ixx="0.0001" ixy="0.0" ixz="0.0" iyy="0.0001" iyz="0.0" izz="0.0001"/>
       </inertial>
     </link>
 

--- a/urdf/sensors/oem_heading_sensor.xacro
+++ b/urdf/sensors/oem_heading_sensor.xacro
@@ -3,8 +3,8 @@
   <xacro:macro name="oem_heading_sensor" params="name:=heading">
     <link name="${namespace}/${name}">
       <inertial>
-        <mass value="0.5"/>
-        <inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001"/>
+        <mass value="0.01"/>
+        <inertia ixx="0.0001" ixy="0.0" ixz="0.0" iyy="0.0001" iyz="0.0" izz="0.0001"/>
       </inertial>
     </link>
     <joint name="${namespace}/${name}_joint" type="fixed">

--- a/urdf/sensors/pano_array.xacro
+++ b/urdf/sensors/pano_array.xacro
@@ -16,11 +16,11 @@
         </geometry>
       </collision>
       <inertial>
-        <mass value="0.3"/>
+        <mass value="0.01"/>
         <inertia
-          ixx="0.0000450"
-          iyy="0.0001746"
-          izz="0.0001746"
+          ixx="0.0001"
+          iyy="0.0001"
+          izz="0.0001"
           ixy="0"
           ixz="0"
           iyz="0"/>

--- a/urdf/sensors/pano_camera.xacro
+++ b/urdf/sensors/pano_camera.xacro
@@ -18,11 +18,11 @@
       </collision>
       <!-- Model inertia as box with <size>0.078 0.03 0.03</size> -->
       <inertial>
-        <mass value="0.3"/>
+        <mass value="0.01"/>
         <inertia
-          ixx="0.0000450"
-          iyy="0.0001746"
-          izz="0.0001746"
+          ixx="0.0001"
+          iyy="0.0001"
+          izz="0.0001"
           ixy="0"
           ixz="0"
           iyz="0"/>

--- a/urdf/sensors/pano_camera.xacro
+++ b/urdf/sensors/pano_camera.xacro
@@ -16,7 +16,7 @@
           <cylinder radius="0.015" length="0.042"/>
         </geometry>
       </collision>
-      <!-- Model inertia as box with <size>0.078 0.03 0.03</size> -->
+      <!-- Near-zero inertia: sensor mass is accounted for in hull_mass -->
       <inertial>
         <mass value="0.01"/>
         <inertia

--- a/urdf/sensors/radar.xacro
+++ b/urdf/sensors/radar.xacro
@@ -5,18 +5,8 @@
                                         x:=0.7 y:=0 z:=1.5
                                         R:=0 P:=0 Y:=0">
 
+    <!-- TF frame only — hull mesh already includes radar dome visual. -->
     <link name="${namespace}/${name}">
-      <visual name="${name}_visual">
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <cylinder radius="0.255" length="0.223"/>
-        </geometry>
-      </visual>
-      <collision name="${name}_collision">
-        <geometry>
-          <cylinder radius="0.255" length="0.223"/>
-        </geometry>
-      </collision>
       <inertial>
         <mass value="0.01"/>
         <inertia

--- a/urdf/sensors/radar.xacro
+++ b/urdf/sensors/radar.xacro
@@ -18,11 +18,11 @@
         </geometry>
       </collision>
       <inertial>
-        <mass value="5.9"/>
+        <mass value="0.01"/>
         <inertia
-          ixx="0.12"
-          iyy="0.12"
-          izz="0.096"
+          ixx="0.0001"
+          iyy="0.0001"
+          izz="0.0001"
           ixy="0"
           ixz="0"
           iyz="0"/>


### PR DESCRIPTION
## Summary

- Remove radar visual/collision (hull mesh has it), keep TF frame
- Replace engine/propeller jetdrive model with Alamarin-Jet AJ 160 waterjet: mount (fixed) → deflector (revolute ±30°) → impeller (continuous)
- Replace static MBES with retractable ram (prismatic, 0 to -226mm) + MBES TF frame
- Update ben_mesh.xacro with new macro names, positions, and includes
- All non-base_link masses 0.01 kg to prevent inertia cross-coupling

## Test plan

- [x] Xacro processes without errors
- [x] Package builds successfully
- [x] BEN floats stably in Gazebo with waves
- [x] BEN moves with thrust command
- [ ] Steering deflector responds to position commands
- [ ] MBES ram extends/retracts

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
