### PR TITLE
Add Garmin sidescan TF frames (placeholder geometry) (closes #13)

### DIFF
--- a/urdf/ben_mesh.xacro
+++ b/urdf/ben_mesh.xacro
@@ -66,6 +66,14 @@
   <xacro:property name="mbes_y" value="0.0" />
   <xacro:property name="mbes_z" value="-0.4" />
 
+  <!-- Garmin GCV-20 sidescan (hull-mounted, relative to MRU).
+       PLACEHOLDER: ~0.5 m forward of the MBES, glued to the hull with the
+       transducer faces ~1 cm below it. Anchored to the MBES offsets so it
+       tracks the same hull reference; refine once the install is measured. -->
+  <xacro:property name="garmin_sidescan_x" value="${mbes_x + 0.5}" />
+  <xacro:property name="garmin_sidescan_y" value="${mbes_y}" />
+  <xacro:property name="garmin_sidescan_z" value="${mbes_z - 0.01}" />
+
   <!-- GPS (POSMV-mounted, relative to motion_sensor) -->
   <xacro:property name="gps_x" value="-0.953" />
   <xacro:property name="gps_y" value="0.103" />
@@ -149,6 +157,11 @@
   <xacro:include filename="$(find ben_description)/urdf/sensors/mbes.xacro" />
   <xacro:ben_mbes name="mbes"
     x="${mru_x + mbes_x}" y="${mru_y + mbes_y}" z="${mru_z + mbes_z}"/>
+
+  <xacro:include filename="$(find ben_description)/urdf/sensors/garmin_sidescan.xacro" />
+  <xacro:ben_garmin_sidescan name="garmin_sidescan"
+    x="${mru_x + garmin_sidescan_x}" y="${mru_y + garmin_sidescan_y}"
+    z="${mru_z + garmin_sidescan_z}"/>
 
   <!-- POSMV-mounted sensors (positions relative to motion_sensor) -->
 

--- a/urdf/sensors/garmin_sidescan.xacro
+++ b/urdf/sensors/garmin_sidescan.xacro
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <!-- Garmin GCV-20 sidescan sonar — TF frames only (no visual/collision).
+
+       The garmin_sidescan driver publishes one RawSonarImage per channel, each
+       stamped with its own frame_id (<name>_port / _starboard / _down). Mounting
+       and per-beam orientation live here in TF, never in the driver.
+
+       Per-channel range axis is the frame's local +Z (rviz_sonar_image places a
+       fixed beam's samples along +Z when rx/tx steering = 0):
+         _down       +Z points down   (matches the MBES transducer convention)
+         _port       +Z points to port (+Y)
+         _starboard  +Z points to starboard (-Y)
+
+       PLACEHOLDER: side-scan grazing tilt is 0 (port/starboard beams horizontal).
+       Real side-scan fires a few tens of degrees below horizontal — refine the
+       _port/_starboard pitch once the install is measured/calibrated. -->
+  <xacro:macro name="ben_garmin_sidescan" params="name x:=0 y:=0 z:=0">
+
+    <!-- Mount frame, aligned with base_link (X fwd, Y port, Z up). -->
+    <link name="${namespace}/${name}">
+      <inertial>
+        <mass value="0.01"/>
+        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
+                 iyy="0.0001" iyz="0.0" izz="0.0001"/>
+      </inertial>
+    </link>
+
+    <joint name="${namespace}/base_link_to_${name}_joint" type="fixed">
+      <origin xyz="${x} ${y} ${z}" rpy="0 0 0"/>
+      <parent link="${namespace}/base_link"/>
+      <child link="${namespace}/${name}"/>
+    </joint>
+
+    <!-- Down-look (water-column) beam: +Z down. -->
+    <link name="${namespace}/${name}_down">
+      <inertial>
+        <mass value="0.01"/>
+        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
+                 iyy="0.0001" iyz="0.0" izz="0.0001"/>
+      </inertial>
+    </link>
+    <joint name="${namespace}/${name}_to_${name}_down_joint" type="fixed">
+      <origin xyz="0 0 0" rpy="${radians(180)} 0 0"/>
+      <parent link="${namespace}/${name}"/>
+      <child link="${namespace}/${name}_down"/>
+    </joint>
+
+    <!-- Port side-scan beam: +Z to port (+Y). -->
+    <link name="${namespace}/${name}_port">
+      <inertial>
+        <mass value="0.01"/>
+        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
+                 iyy="0.0001" iyz="0.0" izz="0.0001"/>
+      </inertial>
+    </link>
+    <joint name="${namespace}/${name}_to_${name}_port_joint" type="fixed">
+      <origin xyz="0 0 0" rpy="${radians(-90)} 0 0"/>
+      <parent link="${namespace}/${name}"/>
+      <child link="${namespace}/${name}_port"/>
+    </joint>
+
+    <!-- Starboard side-scan beam: +Z to starboard (-Y). -->
+    <link name="${namespace}/${name}_starboard">
+      <inertial>
+        <mass value="0.01"/>
+        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
+                 iyy="0.0001" iyz="0.0" izz="0.0001"/>
+      </inertial>
+    </link>
+    <joint name="${namespace}/${name}_to_${name}_starboard_joint" type="fixed">
+      <origin xyz="0 0 0" rpy="${radians(90)} 0 0"/>
+      <parent link="${namespace}/${name}"/>
+      <child link="${namespace}/${name}_starboard"/>
+    </joint>
+
+  </xacro:macro>
+</robot>


### PR DESCRIPTION
## Summary

Add TF frames for the Garmin GCV-20 sidescan sonar so the `garmin_sidescan`
driver's per-channel `frame_id`s resolve in the TF tree. Per the driver
convention, transducer mounting/orientation lives in TF, not driver params.

## Changes

- New `urdf/sensors/garmin_sidescan.xacro` — `ben_garmin_sidescan` macro: a mount
  frame plus `_down` / `_port` / `_starboard` channel frames (TF-only, like
  `radar.xacro`). Range axis = each frame's local **+Z** (this is where
  `rviz_sonar_image` places a fixed beam's samples): `_down` faces down (matching
  the MBES convention), `_port`/`_starboard` fire to the sides.
- Instantiate in `ben_mesh.xacro`, anchored to the MBES: **0.5 m forward, glued
  to the hull** (`z = mbes_z - 0.01`), per the operator's placeholder geometry.

## Naming

Identifiers are `garmin_sidescan(_port/_starboard/_down)`, not `gcv` — the device
name is obscure. "GCV-20" appears only in descriptive comments.

## Placeholder caveats

- Side-scan grazing tilt is **0** (port/starboard beams horizontal); real
  side-scan fires tens of degrees below horizontal — refine once the install is
  measured/calibrated.
- Mount offset is anchored to the MBES per the operator's description; replace
  with surveyed offsets when available.

## Validation

`xacro` expands clean (`namespace:=bizzy`) and `check_urdf` parses the model;
all four `bizzy/garmin_sidescan*` frames present.

Closes #13. Part of the BizzyBoat Garmin sidescan wiring (driver:
rolker/marine_tools#17; generic launch: rolker/marine_tools#20). Launch +
recording wiring lands separately in `unh_echoboats_project11`.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
